### PR TITLE
Issue #69: Modified RightCurly 

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -60,7 +60,11 @@
             <property name="allowEmptyLoopBody" value="true"/>
         </module>
         <module name="RightCurly">
-            <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT, LAMBDA"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT, LAMBDA"/>
+        </module>
+        <module name="RightCurly">
+            <property name="tokens" value="LITERAL_FOR, LITERAL_WHILE"/>
+            <property name="option" value="alone"/>
         </module>
 
         <!-- Class Design checks -->


### PR DESCRIPTION
Issue #69 
Separated tokens `LITERAL_FOR` and `LITERAL_WHILE` from others in `RightCurly` module in `checkstyle.xml` so that they have `alone` option.