### PR TITLE
Issue #55: Add custom notification handler for Firebase

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.macbitsgoa.ard">
 
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"></uses-permission>
+    <uses-permission-sdk-23 android:name="android.permission.WRITE_EXTERNAL_STORAGE"></uses-permission-sdk-23>
     <application
         android:name="com.macbitsgoa.ard.ARD"
         android:allowBackup="true"

--- a/app/src/main/java/com/macbitsgoa/ard/utils/HandleFirebaseMessages.java
+++ b/app/src/main/java/com/macbitsgoa/ard/utils/HandleFirebaseMessages.java
@@ -1,0 +1,66 @@
+package com.macbitsgoa.ard.utils;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.util.Log;
+
+import com.google.firebase.messaging.FirebaseMessagingService;
+import com.google.firebase.messaging.RemoteMessage;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+
+public class HandleFirebaseMessages extends FirebaseMessagingService {
+
+    public static Bitmap getBitmapFromURL(String src) {
+        try {
+            URL url = new URL(src);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setDoInput(true);
+            connection.connect();
+            InputStream input = connection.getInputStream();
+            return BitmapFactory.decodeStream(input);
+        } catch (IOException e) {
+            // Log exception
+            Log.e("TAG", "fucked man " + e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    public void onMessageReceived(RemoteMessage remoteMessage) {
+
+        Map<String, String> data = remoteMessage.getData();
+
+        if (data != null) {
+
+            String type = data.get("type");
+            NotificationHelper helper = new NotificationHelper(this);
+            switch (type) {
+                case "picture":
+                    Bitmap image = getBitmapFromURL(data.get("imageURL"));
+                    helper.pictureNotif(image, data.get("title"));
+                    break;
+                case "url":
+                    helper.urlNotif(data.get("title"), data.get("url"));
+                    break;
+                case "textLong":
+                    helper.bigTextNotif(data.get("title"), data.get("message"), data.get("author"));
+                    break;
+                case "textShort":
+                    helper.smallTextNotif(data.get("title"), data.get("message"));
+                    break;
+                case "list":
+                    String[] listItems = data.get("list").split("\n");
+                    helper.listNotif(listItems, data.get("title"));
+                    break;
+
+            }
+
+        }
+    }
+
+}

--- a/app/src/main/java/com/macbitsgoa/ard/utils/NotificationHelper.java
+++ b/app/src/main/java/com/macbitsgoa/ard/utils/NotificationHelper.java
@@ -1,0 +1,125 @@
+package com.macbitsgoa.ard.utils;
+
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.provider.MediaStore;
+import android.support.v4.app.NotificationCompat;
+
+import com.macbitsgoa.ard.R;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Random;
+
+public class NotificationHelper {
+
+    private Context context;
+    private Random random;
+    private NotificationManager notificationManager;
+
+    public NotificationHelper(Context ctx) {
+        random = new Random();
+        context = ctx;
+        notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+    }
+
+    public void smallTextNotif(String title, String message) {//TODO : add icon
+        NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context);
+        mBuilder.setSmallIcon(android.R.mipmap.sym_def_app_icon);
+        mBuilder.setContentTitle(title);
+        mBuilder.setContentText(message);
+
+        notificationManager.notify(random.nextInt(), mBuilder.build());
+    }
+
+    public void urlNotif(String title, String url) {//TODO : add icon
+        NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context);
+        mBuilder.setSmallIcon(android.R.mipmap.sym_def_app_icon);
+        mBuilder.setContentTitle(title);
+        mBuilder.setContentText("Click to open url");
+
+        Intent openUrl = new Intent(Intent.ACTION_VIEW);
+        openUrl.setData(Uri.parse(url));
+
+        PendingIntent urlIntent = PendingIntent.getActivity(context, random.nextInt(), openUrl, PendingIntent.FLAG_CANCEL_CURRENT);
+        mBuilder.setContentIntent(urlIntent);
+
+        notificationManager.notify(random.nextInt(), mBuilder.build());
+    }
+
+
+    public void listNotif(String[] messages, String title) {
+        NotificationCompat.InboxStyle inboxStyle =
+                new NotificationCompat.InboxStyle();
+
+        inboxStyle.setBigContentTitle(title);
+        for (int i = 0; i < (messages.length < 4 ? messages.length : 4); i++)
+            inboxStyle.addLine(messages[i]);
+
+        int rem = messages.length - 4;
+        if (rem > 0)
+            inboxStyle.setSummaryText("+" + rem + "more..");
+        NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context)
+                .setStyle(inboxStyle)
+                .setContentTitle(title)
+                .setContentText(context.getString(R.string.newListMessage));
+        mBuilder.setSmallIcon(android.R.mipmap.sym_def_app_icon);
+
+        ///  .addAction("View messages",TODO: pending intent here);
+        notificationManager.notify(random.nextInt(), mBuilder.build());
+    }
+
+    public void bigTextNotif(String title, String message, String summaryText) {
+        NotificationCompat.BigTextStyle bigText = new NotificationCompat.BigTextStyle();
+        bigText.bigText(message);
+        bigText.setBigContentTitle(title);
+        bigText.setSummaryText(summaryText);
+        NotificationCompat.Builder mBuilder =
+                new NotificationCompat.Builder(context)
+                        //     .setSmallIcon(add icon here )
+                        //   .setLargeIcon(add icon here)
+                        .setStyle(bigText)
+                        .setContentText(message.substring(0, 50) + (message.length() > 50 ? "....read more" : ""));
+        mBuilder.setSmallIcon(android.R.mipmap.sym_def_app_icon);
+
+        notificationManager.notify(random.nextInt(), mBuilder.build());
+    }
+
+    public void pictureNotif(Bitmap image, String title) {
+        Uri imageUri = getImageUri(image);
+        Intent intent = new Intent();
+        intent.setType("image/jpeg");
+        intent.setAction(Intent.ACTION_SEND);
+        intent.setData(imageUri);
+        intent.putExtra(Intent.EXTRA_STREAM, imageUri);
+        PendingIntent viewPI = PendingIntent.getActivity(context, random.nextInt(), Intent.createChooser(intent, title), PendingIntent.FLAG_CANCEL_CURRENT);
+
+        intent.setType(Intent.ACTION_VIEW);
+        PendingIntent sharePI = PendingIntent.getActivity(context, random.nextInt(), Intent.createChooser(intent, title), PendingIntent.FLAG_CANCEL_CURRENT);
+
+        NotificationCompat.BigPictureStyle bigPictureStyle = new NotificationCompat.BigPictureStyle();
+        bigPictureStyle.bigPicture(image).build();
+
+        NotificationCompat.Builder mbuilder =
+                new NotificationCompat.Builder(context)
+                        //.setSmallIcon(R.drawable.notification_icon)
+                        .setContentTitle(title)
+                        .setStyle(bigPictureStyle)
+                        .addAction(android.R.drawable.ic_menu_share, "show image", sharePI)  //change icon
+                        .addAction(android.R.drawable.ic_menu_view, "Share", viewPI);                     // change icon
+        mbuilder.setSmallIcon(android.R.mipmap.sym_def_app_icon);
+
+        notificationManager.notify(random.nextInt(), mbuilder.build());
+
+    }
+
+    public Uri getImageUri(Bitmap inImage) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        inImage.compress(Bitmap.CompressFormat.JPEG, 100, bytes);
+        String path = MediaStore.Images.Media.insertImage(context.getContentResolver(), inImage, "Title", null);
+        return Uri.parse(path);
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,5 +25,6 @@
 
     <!-- Faq fragment tab layout titles -->
     <string name="tabLayout_faq_general">General</string>
+    <string name="newListMessage">You have a new list</string>
 
 </resources>


### PR DESCRIPTION
Issue #55 
Adds a notification builder which is called whenever a message is received and notifications are build according to the message "type" ,the icons are yet to be added . Requires External Storage permission to handle share and view image from notification panel . TODO : add image viewer in the application itself and call it to view image 