### PR TITLE
Fixed Issue #193

### DIFF
--- a/app/src/main/java/com/macbitsgoa/ard/models/home/HomeItem.java
+++ b/app/src/main/java/com/macbitsgoa/ard/models/home/HomeItem.java
@@ -61,7 +61,7 @@ public class HomeItem extends RealmObject {
      *
      * @param key    Unique key.
      * @param author Author string.
-     * @param date   Date obect of post.
+     * @param date   Date object of post.
      * @param images List of sub section image items.
      * @param texts  List of sub section text items.
      */

--- a/app/src/main/java/com/macbitsgoa/ard/services/HomeService.java
+++ b/app/src/main/java/com/macbitsgoa/ard/services/HomeService.java
@@ -85,6 +85,7 @@ public class HomeService extends BaseIntentService {
      * @return listener for children.
      */
     private ChildEventListener getHomeListener() {
+        //noinspection OverlyLongMethod
         return new ChildEventListener() {
             private Realm database;
 
@@ -106,7 +107,12 @@ public class HomeService extends BaseIntentService {
                     if (hi == null) {
                         hi = r.createObject(HomeItem.class, key);
                     } else {
-                        //if (date.getTime() == hi.getDate().getTime()) return;
+                        if (hi.getImages() != null) {
+                            hi.getImages().deleteAllFromRealm();
+                        }
+                        if (hi.getTexts() != null) {
+                            hi.getTexts().deleteAllFromRealm();
+                        }
                     }
                     hi.setAuthor(author == null
                             || author.length() == 0 ? AHC.DEFAULT_AUTHOR : author);


### PR DESCRIPTION
Fixes #193 
`TextItems` and `PhotoItems` corresponding to `HomeItem` are deleted from
Realm before updating them to avoid duplication.